### PR TITLE
fix(BaseHeaderCell): fix resizing when sorting enabled

### DIFF
--- a/src/components/BaseHeaderCell/BaseHeaderCell.tsx
+++ b/src/components/BaseHeaderCell/BaseHeaderCell.tsx
@@ -58,7 +58,7 @@ export const BaseHeaderCell = <TData, TValue>({
             className={b('header-cell', getHeaderCellClassModes(header), className)}
             colSpan={header.colSpan > 1 ? header.colSpan : undefined}
             rowSpan={rowSpan > 1 ? rowSpan : undefined}
-            onClick={header.column.getToggleSortingHandler()}
+            onMouseDown={header.column.getToggleSortingHandler()}
             aria-sort={getAriaSort(header.column.getIsSorted())}
             aria-colindex={getHeaderCellAriaColIndex(header)}
             {...attributes}


### PR DESCRIPTION
When sorting is enabled and we resize table, we can leave the mouse on the header cell, so the sorting will work