### PR TITLE
Added passing of the getIsCustomRow and renderCustomRowContent callbacks into the BaseRow component.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint:prettier:fix": "prettier --write '**/*.{md,yaml,yml,json}'",
     "lint:styles": "stylelint 'src/**/*.scss' --report-needless-disables",
     "lint:styles:fix": "npm run lint:styles -- --fix",
-    "prepare": "husky",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "start": "storybook dev -p 6006",
     "test": "jest --passWithNoTests",

--- a/src/components/BaseTable/BaseTable.tsx
+++ b/src/components/BaseTable/BaseTable.tsx
@@ -142,6 +142,8 @@ export const BaseTable = React.forwardRef(
             stickyHeader = false,
             withFooter = false,
             withHeader = true,
+            getIsCustomRow,
+            renderCustomRowContent,
         }: BaseTableProps<TData, TScrollElement>,
         ref: React.Ref<HTMLTableElement>,
     ) => {
@@ -208,6 +210,8 @@ export const BaseTable = React.forwardRef(
                     'aria-selected': table.options.enableRowSelection
                         ? row.getIsSelected()
                         : undefined,
+                    getIsCustomRow,
+                    renderCustomRowContent,
                 };
 
                 if (draggableContext) {


### PR DESCRIPTION
The table supports passing the callbacks getIsCustomRow and renderCustomRowContent, but they are not forwarded to the BaseRow component.
