### PR TITLE
fix(TableSettings): popover actions background in dark theme

### DIFF
--- a/src/components/TableSettings/TableSettings.scss
+++ b/src/components/TableSettings/TableSettings.scss
@@ -16,6 +16,6 @@ $block: '.#{variables.$ns}table-settings';
     &__popover-actions {
         position: relative;
         padding: var(--g-spacing-2);
-        background-color: var(--g-color-base-background);
+        background-color: inherit;
     }
 }


### PR DESCRIPTION
Before fix: 
<img width="242" alt="image" src="https://github.com/user-attachments/assets/152317f0-99bc-4e67-9203-aebda8a1326c">

After fix:
<img width="201" alt="image" src="https://github.com/user-attachments/assets/14c96e88-b9bb-4bde-b62e-2b041bc67f9d">
