### PR TITLE
fix(Table): export sortable list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,11 @@
-export {BaseTable, ReorderingProvider, SortIndicator, Table, TableSettings} from './components';
+export {
+    BaseTable,
+    ReorderingProvider,
+    SortIndicator,
+    Table,
+    TableSettings,
+    SortableListContext,
+} from './components';
 export type {
     BaseTableProps,
     ReorderingProviderProps,
@@ -6,6 +13,7 @@ export type {
     TableProps,
     TableSettingsOptions,
     TableSettingsProps,
+    BaseGroupHeaderProps,
 } from './components';
 
 export {


### PR DESCRIPTION
After updating the exported types https://github.com/gravity-ui/table/commit/9415601deb5524ff301e0d9ed69fcec980566696 we can't import the sortable context directly from the components, but we need it for the custom draggable tree 