### PR TITLE
Speed-up getInitialOrderItems

### DIFF
--- a/src/components/TableSettings/TableSettings.utils.ts
+++ b/src/components/TableSettings/TableSettings.utils.ts
@@ -102,10 +102,7 @@ export const getInitialOrderItems = <TData extends unknown>(
     treeItems: Column<TData>[],
     initialOrder: string[],
 ) => {
-    const orderMap = initialOrder.reduce<Record<string, number>>(
-        (acc, id, index) => ({...acc, [id]: index}),
-        {},
-    );
+    const orderMap = Object.fromEntries(initialOrder.map((id, index) => [id, index]));
 
     const stack = [...treeItems];
     const result: Record<string, string[]> = {root: treeItems.map(({id}) => id)};


### PR DESCRIPTION
We are using @gravity-ui/table with a large list of initially hidden columns. TableSettings has some performance issues, and getInitialOrderItems was one of them. Here's a small improvements that makes this function run  ~700x times faster

Benchmark: https://jsbm.dev/8ykBuijHvTvfy