### PR TITLE
fix(BaseTable): sticky header/footer z-index

### DIFF
--- a/src/components/BaseTable/BaseTable.scss
+++ b/src/components/BaseTable/BaseTable.scss
@@ -18,7 +18,7 @@ $block: '.#{variables.$ns}table';
         &_sticky {
             position: sticky;
             inset-block-start: 0;
-            z-index: 1;
+            z-index: 4;
         }
     }
 
@@ -26,7 +26,7 @@ $block: '.#{variables.$ns}table';
         &_sticky {
             position: sticky;
             inset-block-end: 0;
-            z-index: 1;
+            z-index: 4;
         }
     }
 

--- a/src/components/ReorderingProvider/ReorderingProvider.scss
+++ b/src/components/ReorderingProvider/ReorderingProvider.scss
@@ -16,7 +16,7 @@ $dragHandleBlock: '.#{variables.$ns}drag-handle';
         }
 
         &[data-dragging='true'] {
-            z-index: 1;
+            z-index: 5;
 
             pointer-events: none;
 
@@ -27,7 +27,7 @@ $dragHandleBlock: '.#{variables.$ns}drag-handle';
                 position: absolute;
                 inset: 0;
 
-                z-index: 2;
+                z-index: 6;
 
                 content: '';
 


### PR DESCRIPTION
Fix for https://github.com/gravity-ui/table/issues/139