### PR TITLE
fix(selectionColumn): exclude disabled rows from selection

### DIFF
--- a/src/constants/selectionColumn.tsx
+++ b/src/constants/selectionColumn.tsx
@@ -4,19 +4,14 @@ import {getToggleAllEnabledRowsSelectedHandler} from '../utils';
 
 export const selectionColumn: ColumnDef<unknown> = {
     id: '_select',
-    header: ({table}) => {
-        const indeterminate = table.getIsSomeRowsSelected();
-        return (
-            <SelectionCheckbox
-                checked={table.getIsAllRowsSelected()}
-                disabled={
-                    !table.options.enableRowSelection || !table.options.enableMultiRowSelection
-                }
-                indeterminate={indeterminate}
-                onChange={getToggleAllEnabledRowsSelectedHandler(table, indeterminate)}
-            />
-        );
-    },
+    header: ({table}) => (
+        <SelectionCheckbox
+            checked={table.getIsAllRowsSelected()}
+            disabled={!table.options.enableRowSelection || !table.options.enableMultiRowSelection}
+            indeterminate={table.getIsSomeRowsSelected()}
+            onChange={getToggleAllEnabledRowsSelectedHandler(table)}
+        />
+    ),
     cell: (cellContext) => (
         <RangedSelectionCheckbox
             checked={cellContext.row.getIsSelected()}

--- a/src/constants/selectionColumn.tsx
+++ b/src/constants/selectionColumn.tsx
@@ -1,16 +1,22 @@
 import {RangedSelectionCheckbox, SelectionCheckbox} from '../components';
 import type {ColumnDef} from '../types/base';
+import {getToggleAllEnabledRowsSelectedHandler} from '../utils';
 
 export const selectionColumn: ColumnDef<unknown> = {
     id: '_select',
-    header: ({table}) => (
-        <SelectionCheckbox
-            checked={table.getIsAllRowsSelected()}
-            disabled={!table.options.enableRowSelection}
-            indeterminate={table.getIsSomeRowsSelected()}
-            onChange={table.getToggleAllRowsSelectedHandler()}
-        />
-    ),
+    header: ({table}) => {
+        const indeterminate = table.getIsSomeRowsSelected();
+        return (
+            <SelectionCheckbox
+                checked={table.getIsAllRowsSelected()}
+                disabled={
+                    !table.options.enableRowSelection || !table.options.enableMultiRowSelection
+                }
+                indeterminate={indeterminate}
+                onChange={getToggleAllEnabledRowsSelectedHandler(table, indeterminate)}
+            />
+        );
+    },
     cell: (cellContext) => (
         <RangedSelectionCheckbox
             checked={cellContext.row.getIsSelected()}

--- a/src/hooks/useToggleRangeSelectionHandler.ts
+++ b/src/hooks/useToggleRangeSelectionHandler.ts
@@ -35,7 +35,10 @@ export const useToggleRangeSelectionHandler = <TData extends RowData, TValue>(
         } else {
             const startIndex = Math.min(clickedRowIndex, lastSelectedRowIndexRef.current);
             const endIndex = Math.max(clickedRowIndex, lastSelectedRowIndexRef.current);
-            const rowsToSelect = table.getRowModel().rows.slice(startIndex, endIndex + 1);
+            const rowsToSelect = table
+                .getRowModel()
+                .rows.slice(startIndex, endIndex + 1)
+                .filter((rowToSelect) => rowToSelect.getCanSelect());
             const currentRowSelectionState = table.getState().rowSelection;
 
             const rangeAlreadySelected = rowsToSelect.every(({id}) => {

--- a/src/utils/getToggleAllEnabledRowsSelectedHandler.ts
+++ b/src/utils/getToggleAllEnabledRowsSelectedHandler.ts
@@ -1,0 +1,23 @@
+import type {Table} from '@tanstack/table-core';
+
+export function getToggleAllEnabledRowsSelectedHandler<T>(
+    table: Table<T>,
+    isSomeRowsAreSelected: boolean,
+) {
+    return (event: React.ChangeEvent<HTMLInputElement>) => {
+        if (isSomeRowsAreSelected) {
+            const preGroupedFlatRows = table
+                .getPreGroupedRowModel()
+                .flatRows.filter((row) => row.getCanSelect());
+            const tableRowSelection = table.getState().rowSelection;
+
+            const allEnableRowsAreSelected = preGroupedFlatRows.every((row) => {
+                return tableRowSelection[row.id] === true;
+            });
+
+            table.toggleAllRowsSelected(!allEnableRowsAreSelected);
+        } else {
+            table.toggleAllRowsSelected(event.target.checked);
+        }
+    };
+}

--- a/src/utils/getToggleAllEnabledRowsSelectedHandler.ts
+++ b/src/utils/getToggleAllEnabledRowsSelectedHandler.ts
@@ -1,10 +1,8 @@
 import type {Table} from '@tanstack/table-core';
 
-export function getToggleAllEnabledRowsSelectedHandler<T>(
-    table: Table<T>,
-    isSomeRowsAreSelected: boolean,
-) {
+export function getToggleAllEnabledRowsSelectedHandler<T>(table: Table<T>) {
     return (event: React.ChangeEvent<HTMLInputElement>) => {
+        const isSomeRowsAreSelected = table.getIsSomeRowsSelected();
         if (isSomeRowsAreSelected) {
             const preGroupedFlatRows = table
                 .getPreGroupedRowModel()

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,3 +12,4 @@ export * from './getVirtualRowRangeExtractor';
 export * from './shouldRenderFooterCell';
 export * from './shouldRenderFooterRow';
 export * from './shouldRenderHeaderCell';
+export * from './getToggleAllEnabledRowsSelectedHandler';


### PR DESCRIPTION
### Description
Changes in `selectionColumn` to handle non-selectable table rows (`!row.getCanSelect()`):
* **Bulk selection fix**: Rows that should not be selectable are now skipped during bulk selection (Ctrl + Click).
* **Header checkbox fix**: The "Select All" checkbox in the header no longer gets stuck in the `indeterminate` state if any row is not allow to select.
