### PR TITLE
fix(RowActions): clip menu content to popup border radius

### DIFF
--- a/src/components/RowActions/RowActions.scss
+++ b/src/components/RowActions/RowActions.scss
@@ -10,6 +10,7 @@ $block: '.#{variables.$ns}row-actions';
 
     &__popup-menu {
         @include mixins.max-height(200px);
+        border-radius: inherit;
     }
 
     &__popup-menu-item {


### PR DESCRIPTION
before:
<img width="474" height="613" alt="image" src="https://github.com/user-attachments/assets/03608d06-ced9-4b59-ac2b-6231540edf92" />

after:
<img width="515" height="619" alt="image" src="https://github.com/user-attachments/assets/be56d645-e01f-4e06-8237-2db437061393" />
