### PR TITLE
feat(RowActions): widen TableAction.text from string to ReactNode

### DIFF
--- a/src/types/RowActions.ts
+++ b/src/types/RowActions.ts
@@ -2,7 +2,7 @@ import type {MenuItemProps} from '@gravity-ui/uikit';
 import type {Row} from '@tanstack/react-table';
 
 export interface TableAction<TValue> {
-    text: string;
+    text: React.ReactNode;
     handler: (
         item: TValue,
         index: number,


### PR DESCRIPTION
Allow richer menu item content (e.g. JSX, elements) by aligning TableAction.text with Menu.Item's children type (React.ReactNode). Existing string values remain valid; no breaking change for consumers.

Refs: table/src/types/RowActions.ts